### PR TITLE
Increase clientQPS

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	clientQPS   = 200
+	clientQPS   = 300
 	clientBurst = 400
 )
 


### PR DESCRIPTION
Increase clientQPS to 300 to avoid client-throttling issues on the clusters with huge amount of CRDs. Typical for Crossplane clusters.

```
kubectl get crd --no-headers|wc -l
     735
```

Before:

```
 k lineage xnetwork.azure.platformref.upbound.io/ref-azure-network --exclude-types=ev
I0614 01:22:11.224533    8015 request.go:665] Waited for 1.005303667s due to client-side throttling, not priority and fairness, request: GET:https://0.0.0.0:53800/apis/insights.azure.upbound.io/v1beta1/applicationinsightsworkbooktemplates?limit=250
NAME                                                               READY   STATUS      AGE
XNetwork/ref-azure-network                                         True    Available   23m
├── ResourceGroup/ref-azure-network-from-xr-rg                     True    Available   23m
│   └── ProviderConfigUsage/6c6d40e9-f6af-4fc6-ba63-4573cae9b798   -                   23m
├── Subnet/ref-azure-network-from-xr-sn                            True    Available   23m
│   └── ProviderConfigUsage/9922ad04-15ae-4756-8293-4e9f69b53908   -                   23m
└── VirtualNetwork/ref-azure-network-from-xr-vnet                  True    Available   23m
    └── ProviderConfigUsage/5080e5f8-c3b4-428e-90ab-eb74abb8a9d6   -                   23m
```

After:

```
 ~/go/bin/kube-lineage xnetwork.azure.platformref.upbound.io/ref-azure-network --exclude-types=ev
NAME                                                               READY   STATUS      AGE
XNetwork/ref-azure-network                                         True    Available   25m
├── ResourceGroup/ref-azure-network-from-xr-rg                     True    Available   25m
│   └── ProviderConfigUsage/6c6d40e9-f6af-4fc6-ba63-4573cae9b798   -                   25m
├── Subnet/ref-azure-network-from-xr-sn                            True    Available   25m
│   └── ProviderConfigUsage/9922ad04-15ae-4756-8293-4e9f69b53908   -                   25m
└── VirtualNetwork/ref-azure-network-from-xr-vnet                  True    Available   25m
    └── ProviderConfigUsage/5080e5f8-c3b4-428e-90ab-eb74abb8a9d6   -                   25m
```

No throttling event after the QPS bump